### PR TITLE
Add PLA Basic Green

### DIFF
--- a/filaments.json
+++ b/filaments.json
@@ -323,6 +323,23 @@
     }
   },
   {
+    "id": "A00-G0",
+    "sku": "10500",
+    "material": "PLA",
+    "product": "PLA Basic",
+    "color_name": "Green",
+    "color_hex": "164B35FF",
+    "color_hexes": [
+      "164B35FF"
+    ],
+    "weight": 1000,
+    "temp_min": 190,
+    "temp_max": 230,
+    "integrations": {
+      "spoolman": null
+    }
+  },
+  {
     "id": "A00-G02",
     "sku": "10502",
     "material": "PLA",

--- a/manual_additions.json
+++ b/manual_additions.json
@@ -1,12 +1,26 @@
 [
   {
+    "id": "A00-G0",
+    "product": "PLA Basic",
+    "color_hex": "164B35FF",
+    "weight": 1000,
+    "temp_min": 190,
+    "temp_max": 230
+  },
+  {
     "id": "A05-P3",
     "product": "PLA Silk",
-    "color_hex": "EEB1C1FF"
+    "color_hex": "EEB1C1FF",
+    "weight": 1000,
+    "temp_min": 210,
+    "temp_max": 230
   },
   {
     "id": "A05-Y4",
     "product": "PLA Silk",
-    "color_hex": "E5B03DFF"
+    "color_hex": "E5B03DFF",
+    "weight": 1000,
+    "temp_min": 210,
+    "temp_max": 230
   }
 ]


### PR DESCRIPTION
Adds `A00-G0` (PLA Basic Green, SKU 10500, hex `164B35`) via [`manual_additions.json`](manual_additions.json), pending an upstream RFID dump.

Also fills in explicit `weight` / `temp_min` / `temp_max` for the existing PLA Silk Pink and Gold entries instead of relying on sibling backfill, so the source of truth stays in the manual file.

Closes #6